### PR TITLE
Remove CreatedBy tag

### DIFF
--- a/root.tf
+++ b/root.tf
@@ -4,7 +4,6 @@ locals {
   tag_prefix = module.global_variables.tag_prefix
   aws_region = module.global_variables.default_aws_region
   common_tags = map(
-  "CreatedBy", module.caller.caller_arn,
   "Environment", local.environment,
   "Owner", "TDR",
   "Terraform", true


### PR DESCRIPTION
Remove global `CreatedBy` tag from every resource. This was intended to store the user who ran Terraform to create the resource, but it was actually updated every time we ran Terraform, causing a lot of churn and overwriting the original value.

We couldn't find a way to add the tag on resource creation and freeze it, so it seems better to remove it.

Terraform will eventually be run by a Terraform user in CI, so the `CreatedBy` tag wouldn't be so useful anyway.