### PR TITLE
Add authentication for file checkers to use to access GraphQL API

### DIFF
--- a/modules/api/api_gateway.tf
+++ b/modules/api/api_gateway.tf
@@ -1,9 +1,3 @@
-resource "aws_api_gateway_resource" "graphql_endpoint" {
-  path_part   = "graphql"
-  parent_id   = aws_api_gateway_rest_api.graphql_api.root_resource_id
-  rest_api_id = aws_api_gateway_rest_api.graphql_api.id
-}
-
 resource "aws_api_gateway_rest_api" "graphql_api" {
   name = "tdr-graphql-api-${var.environment}"
 
@@ -14,104 +8,23 @@ resource "aws_api_gateway_rest_api" "graphql_api" {
 
 resource "aws_api_gateway_deployment" "graphql_api" {
   rest_api_id = aws_api_gateway_rest_api.graphql_api.id
-  depends_on  = ["aws_api_gateway_integration.graphql_api"]
 
-  # You must update the version if you make any changes that require a
-  # redeployment of the API Gateway.
-  # Terraform doesn't provide a good way to automatically redeploy the Gateway,
-  # but we could look into less manual workarounds, e.g.:
-  # https://github.com/terraform-providers/terraform-provider-aws/issues/162
-  # https://medium.com/coryodaniel/til-forcing-terraform-to-deploy-a-aws-api-gateway-deployment-ed36a9f60c1a
   variables = {
-    version = 5
+    # You must update the version if you make any changes that require a
+    # redeployment of the API Gateway.
+    # Terraform doesn't provide a good way to automatically redeploy the
+    # Gateway, but we could look into less manual workarounds, e.g.:
+    # https://github.com/terraform-providers/terraform-provider-aws/issues/162
+    # https://medium.com/coryodaniel/til-forcing-terraform-to-deploy-a-aws-api-gateway-deployment-ed36a9f60c1a
+    version      = 7
+    # Force this resource to depend on the API Gateway integrations. We cannot
+    # use 'depends_on' because 'depends_on' does not work with resources inside
+    # modules. See: https://github.com/hashicorp/terraform/issues/17101
+    dependencies = "${module.graphql_frontend_endpoint.integration_id}"
   }
 
   lifecycle {
       create_before_destroy = true
-  }
-}
-
-resource "aws_api_gateway_method" "graphql_api" {
-  rest_api_id   = aws_api_gateway_rest_api.graphql_api.id
-  resource_id   = aws_api_gateway_resource.graphql_endpoint.id
-  http_method   = "POST"
-  authorization = "COGNITO_USER_POOLS"
-  authorizer_id = aws_api_gateway_authorizer.graphql_api_auth.id
-}
-
-resource "aws_api_gateway_method_response" "graphql_api_response_200" {
-  rest_api_id = aws_api_gateway_rest_api.graphql_api.id
-  resource_id = aws_api_gateway_resource.graphql_endpoint.id
-  http_method = aws_api_gateway_method.graphql_api.http_method
-  status_code = "200"
-  response_parameters = {
-    "method.response.header.Access-Control-Allow-Origin" = true
-  }
-}
-
-resource "aws_api_gateway_integration" "graphql_api" {
-  rest_api_id             = aws_api_gateway_rest_api.graphql_api.id
-  resource_id             = aws_api_gateway_resource.graphql_endpoint.id
-  http_method             = aws_api_gateway_method.graphql_api.http_method
-  integration_http_method = "POST"
-  type                    = "AWS"
-  uri                     = "arn:aws:apigateway:${var.aws_region}:lambda:path/2015-03-31/functions/${aws_lambda_function.api.arn}/invocations"
-}
-
-resource "aws_api_gateway_integration_response" "graphql_api" {
-  rest_api_id         = aws_api_gateway_rest_api.graphql_api.id
-  resource_id         = aws_api_gateway_resource.graphql_endpoint.id
-  http_method         = aws_api_gateway_integration.graphql_api.http_method
-  status_code         = aws_api_gateway_method_response.graphql_api_response_200.status_code
-  response_parameters = {
-    // TODO: Lock down to TDR frontend once we have a domain
-    "method.response.header.Access-Control-Allow-Origin" = "'*'"
-  }
-}
-
-resource "aws_api_gateway_method" "graphql_options" {
-  rest_api_id   = aws_api_gateway_rest_api.graphql_api.id
-  resource_id   = aws_api_gateway_resource.graphql_endpoint.id
-  http_method   = "OPTIONS"
-  authorization = "NONE"
-}
-
-resource "aws_api_gateway_method_response" "graphql_options_response_200" {
-  rest_api_id         = aws_api_gateway_rest_api.graphql_api.id
-  resource_id         = aws_api_gateway_resource.graphql_endpoint.id
-  http_method         = aws_api_gateway_method.graphql_options.http_method
-  status_code         = "200"
-  response_models     = {
-    "application/json" = "Empty"
-  }
-  response_parameters = {
-    "method.response.header.Access-Control-Allow-Headers" = true,
-    "method.response.header.Access-Control-Allow-Methods" = true,
-    "method.response.header.Access-Control-Allow-Origin" = true
-  }
-}
-
-resource "aws_api_gateway_integration" "graphql_options" {
-  rest_api_id           = aws_api_gateway_rest_api.graphql_api.id
-  resource_id           = aws_api_gateway_resource.graphql_endpoint.id
-  http_method           = aws_api_gateway_method.graphql_options.http_method
-  type                  = "MOCK"
-  passthrough_behavior = "WHEN_NO_MATCH"
-  request_templates     = {
-    "application/json" = "{ 'statusCode': 200 }"
-  }
-}
-
-resource "aws_api_gateway_integration_response" "graphql_options" {
-  rest_api_id         = aws_api_gateway_rest_api.graphql_api.id
-  resource_id         = aws_api_gateway_resource.graphql_endpoint.id
-  http_method         = aws_api_gateway_integration.graphql_options.http_method
-  status_code         = aws_api_gateway_method_response.graphql_options_response_200.status_code
-  response_parameters = {
-    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
-    "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS,POST,PUT'",
-    # TODO: Lock down to TDR frontend once we have a domain
-    "method.response.header.Access-Control-Allow-Origin" = "'*'"
   }
 }
 
@@ -123,17 +36,24 @@ resource "aws_api_gateway_stage" "graphql_api_deployed_stage" {
   tags = var.common_tags
 }
 
-resource "aws_lambda_permission" "graphql_api" {
-  statement_id  = "GraphQLApi-${var.environment}"
-  action        = "lambda:InvokeFunction"
-  function_name = aws_lambda_function.api.function_name
-  principal     = "apigateway.amazonaws.com"
-  source_arn    = "arn:aws:execute-api:${var.aws_region}:${var.account_id}:${aws_api_gateway_rest_api.graphql_api.id}/*/${aws_api_gateway_method.graphql_api.http_method}${aws_api_gateway_resource.graphql_endpoint.path}"
-}
-
 resource "aws_api_gateway_authorizer" "graphql_api_auth" {
   name          = "graphql-api-authorizer-${var.environment}"
   type          = "COGNITO_USER_POOLS"
   rest_api_id   = aws_api_gateway_rest_api.graphql_api.id
   provider_arns = [var.user_pool_arn]
+}
+
+module "graphql_frontend_endpoint" {
+  source = "../graphql_api_endpoint"
+
+  relative_path      = "graphql"
+  rest_api_id        = aws_api_gateway_rest_api.graphql_api.id
+  parent_resource_id = aws_api_gateway_rest_api.graphql_api.root_resource_id
+  authorization_type = "COGNITO_USER_POOLS"
+  authorizer_id      = aws_api_gateway_authorizer.graphql_api_auth.id
+  lambda_arn         = aws_lambda_function.api.arn
+  lambda_name        = aws_lambda_function.api.function_name
+  aws_region         = var.aws_region
+  environment        = var.environment
+  account_id         = var.account_id
 }

--- a/modules/graphql_api_endpoint/api_endpoint.tf
+++ b/modules/graphql_api_endpoint/api_endpoint.tf
@@ -1,0 +1,97 @@
+resource "aws_api_gateway_resource" "graphql_endpoint" {
+  path_part   = var.relative_path
+  parent_id   = var.parent_resource_id
+  rest_api_id = var.rest_api_id
+}
+
+resource "aws_api_gateway_method" "graphql_api" {
+  rest_api_id   = var.rest_api_id
+  resource_id   = aws_api_gateway_resource.graphql_endpoint.id
+  http_method   = "POST"
+  authorization = var.authorization_type
+  authorizer_id = var.authorizer_id
+}
+
+resource "aws_api_gateway_method_response" "graphql_api_response_200" {
+  rest_api_id = var.rest_api_id
+  resource_id = aws_api_gateway_resource.graphql_endpoint.id
+  http_method = aws_api_gateway_method.graphql_api.http_method
+  status_code = "200"
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Origin" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "graphql_api" {
+  rest_api_id             = var.rest_api_id
+  resource_id             = aws_api_gateway_resource.graphql_endpoint.id
+  http_method             = aws_api_gateway_method.graphql_api.http_method
+  integration_http_method = "POST"
+  type                    = "AWS"
+  uri                     = "arn:aws:apigateway:${var.aws_region}:lambda:path/2015-03-31/functions/${var.lambda_arn}/invocations"
+}
+
+resource "aws_api_gateway_integration_response" "graphql_api" {
+  rest_api_id         = var.rest_api_id
+  resource_id         = aws_api_gateway_resource.graphql_endpoint.id
+  http_method         = aws_api_gateway_integration.graphql_api.http_method
+  status_code         = aws_api_gateway_method_response.graphql_api_response_200.status_code
+  response_parameters = {
+    // TODO: Lock down to TDR frontend once we have a domain
+    "method.response.header.Access-Control-Allow-Origin" = "'*'"
+  }
+}
+
+resource "aws_api_gateway_method" "graphql_options" {
+  rest_api_id   = var.rest_api_id
+  resource_id   = aws_api_gateway_resource.graphql_endpoint.id
+  http_method   = "OPTIONS"
+  authorization = "NONE"
+}
+
+resource "aws_api_gateway_method_response" "graphql_options_response_200" {
+  rest_api_id         = var.rest_api_id
+  resource_id         = aws_api_gateway_resource.graphql_endpoint.id
+  http_method         = aws_api_gateway_method.graphql_options.http_method
+  status_code         = "200"
+  response_models     = {
+    "application/json" = "Empty"
+  }
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = true,
+    "method.response.header.Access-Control-Allow-Methods" = true,
+    "method.response.header.Access-Control-Allow-Origin" = true
+  }
+}
+
+resource "aws_api_gateway_integration" "graphql_options" {
+  rest_api_id           = var.rest_api_id
+  resource_id           = aws_api_gateway_resource.graphql_endpoint.id
+  http_method           = aws_api_gateway_method.graphql_options.http_method
+  type                  = "MOCK"
+  passthrough_behavior  = "WHEN_NO_MATCH"
+  request_templates     = {
+    "application/json" = "{ 'statusCode': 200 }"
+  }
+}
+
+resource "aws_api_gateway_integration_response" "graphql_options" {
+  rest_api_id         = var.rest_api_id
+  resource_id         = aws_api_gateway_resource.graphql_endpoint.id
+  http_method         = aws_api_gateway_integration.graphql_options.http_method
+  status_code         = aws_api_gateway_method_response.graphql_options_response_200.status_code
+  response_parameters = {
+    "method.response.header.Access-Control-Allow-Headers" = "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token'",
+    "method.response.header.Access-Control-Allow-Methods" = "'GET,OPTIONS,POST,PUT'",
+    # TODO: Lock down to TDR frontend once we have a domain
+    "method.response.header.Access-Control-Allow-Origin" = "'*'"
+  }
+}
+
+resource "aws_lambda_permission" "graphql_api" {
+  statement_id  = "GraphQLApi-${var.relative_path}-${var.environment}"
+  action        = "lambda:InvokeFunction"
+  function_name = var.lambda_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "arn:aws:execute-api:${var.aws_region}:${var.account_id}:${var.rest_api_id}/*/${aws_api_gateway_method.graphql_api.http_method}${aws_api_gateway_resource.graphql_endpoint.path}"
+}

--- a/modules/graphql_api_endpoint/outputs.tf
+++ b/modules/graphql_api_endpoint/outputs.tf
@@ -1,0 +1,3 @@
+output "integration_id" {
+  value = aws_api_gateway_integration.graphql_api.id
+}

--- a/modules/graphql_api_endpoint/variables.tf
+++ b/modules/graphql_api_endpoint/variables.tf
@@ -1,0 +1,50 @@
+variable "aws_region" {
+  description = "The AWS region"
+  default     = "eu-west-2"
+}
+
+variable "environment" {
+  description = "Environment resource is running in"
+  type        = string
+}
+
+variable "account_id" {
+  description = "The account id of the user"
+  type        = string
+}
+
+variable "rest_api_id" {
+  description = "The ID of the API Gateway REST API definition"
+  type        = string
+}
+
+variable "relative_path" {
+  description = "The path of the endpoint, relative to its parent resource"
+  type        = string
+}
+
+variable "parent_resource_id" {
+  description = "The ID of this module's API Gateway parent resource"
+  type        = string
+}
+
+variable "authorization_type" {
+  type        = string
+  default     = "NONE"
+}
+
+variable "authorizer_id" {
+  description = "The ID of the API Gateway authorizer"
+  type        = string
+  default     = ""
+}
+
+variable "lambda_arn" {
+  description = "The ARN of the Lambda function that backs this API endpoint"
+  type        = string
+}
+
+variable "lambda_name" {
+  description = "The name of the Lambda function that backs this API endpoint"
+  type        = string
+}


### PR DESCRIPTION
Add IAM user, policy and API keys that the backend file checks can use to call the GraphQL API, since they cannot use Cognito credentials like the frontend. This will give them [access to the API using IAM permissions](https://docs.aws.amazon.com/apigateway/latest/developerguide/permissions.html).

Also add a separate API endpoint for the backend to call, since you cannot use Cognito and IAM auth on the same endpoint.

Probably easiest to review commit-by-commit because the first commit refactors the existing code to extract an API endpoint module.