### PR TITLE
Allow API to start consignment export task

### DIFF
--- a/modules/api/ecs.tf
+++ b/modules/api/ecs.tf
@@ -28,13 +28,13 @@ data "template_file" "app" {
 
 resource "aws_ecs_task_definition" "app" {
   family                   = "${var.app_name}-${var.environment}"
-  execution_role_arn       = var.ecs_task_execution_role
+  execution_role_arn       = aws_iam_role.api_ecs_execution.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.fargate_cpu
   memory                   = var.fargate_memory
   container_definitions    = data.template_file.app.rendered
-  task_role_arn            = var.ecs_task_execution_role
+  task_role_arn            = aws_iam_role.api_ecs_task.arn
 
   tags = merge(
   var.common_tags,
@@ -89,6 +89,69 @@ resource "aws_security_group" "ecs_tasks" {
   )
 }
 
+resource "aws_iam_role" "api_ecs_execution" {
+  name = "api_ecs_execution_role_${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = merge(
+    var.common_tags,
+    map(
+      "Name", "api-ecs-execution-iam-role-${var.environment}",
+    )
+  )
+}
+
+resource "aws_iam_role" "api_ecs_task" {
+  name = "api_ecs_task_role_${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = merge(
+    var.common_tags,
+    map(
+      "Name", "api-ecs-task-iam-role-${var.environment}",
+    )
+  )
+}
+
+data "aws_iam_policy_document" "ecs_assume_role" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions   = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "api_ecs_execution_ssm" {
+  role       = aws_iam_role.api_ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "api_ecs_execution" {
+  role       = aws_iam_role.api_ecs_execution.name
+  policy_arn = aws_iam_policy.api_ecs_execution.arn
+}
+
+resource "aws_iam_policy" "api_ecs_execution" {
+  name   = "api_ecs_execution_policy_${var.environment}"
+  path   = "/"
+  policy = data.aws_iam_policy_document.api_ecs_execution.json
+}
+
+data "aws_iam_policy_document" "api_ecs_execution" {
+  statement {
+    actions   = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [aws_cloudwatch_log_group.tdr_graphql_log_group.arn]
+  }
+}
 
 resource "aws_api_gateway_vpc_link" "graphql_vpc_link" {
   name        = "graphql-vpc-link-${var.environment}"

--- a/modules/api/migrations.tf
+++ b/modules/api/migrations.tf
@@ -74,7 +74,28 @@ data "aws_iam_policy_document" "database_migration_task_assume_role" {
 
 resource "aws_iam_role_policy_attachment" "database_migration_task_execution_policy" {
   role       = aws_iam_role.database_migration_task_excution_role.name
-  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMFullAccess"
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "database_migration_task_execution" {
+  role       = aws_iam_role.database_migration_task_excution_role.name
+  policy_arn = aws_iam_policy.database_migration_task_execution.arn
+}
+
+resource "aws_iam_policy" "database_migration_task_execution" {
+  name   = "database_migration_task_execution_policy_${var.environment}"
+  path   = "/"
+  policy = data.aws_iam_policy_document.database_migration_task_execution.json
+}
+
+data "aws_iam_policy_document" "database_migration_task_execution" {
+  statement {
+    actions   = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [aws_cloudwatch_log_group.database_migration_task.arn]
+  }
 }
 
 resource "aws_cloudwatch_log_group" "database_migration_task" {

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -47,8 +47,6 @@ variable "fargate_cpu" {}
 
 variable "fargate_memory" {}
 
-variable "ecs_task_execution_role" {}
-
 variable "ecs_vpc" {}
 
 variable "ecs_public_subnet" {}

--- a/modules/api/variables.tf
+++ b/modules/api/variables.tf
@@ -61,6 +61,10 @@ variable "export_task_id" {
   description = "ID of ECS task for exporting consignments"
 }
 
+variable "export_task_arn" {
+  description = "ARN of the latest revision of the ECS task for exporting consignments"
+}
+
 variable "export_container_id" {
   description = "Container ID of ECS task for exporting consignments"
 }

--- a/modules/consignment_export/ecs.tf
+++ b/modules/consignment_export/ecs.tf
@@ -71,6 +71,27 @@ data "aws_iam_policy_document" "consignment_export_execution_assume_role" {
   }
 }
 
+resource "aws_iam_role_policy_attachment" "consignment_export_execution" {
+  role       = aws_iam_role.consignment_export_execution.name
+  policy_arn = aws_iam_policy.consignment_export_execution.arn
+}
+
+resource "aws_iam_policy" "consignment_export_execution" {
+  name   = "consignment_export_execution_policy_${var.environment}"
+  path   = "/"
+  policy = data.aws_iam_policy_document.consignment_export_execution.json
+}
+
+data "aws_iam_policy_document" "consignment_export_execution" {
+  statement {
+    actions   = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [aws_cloudwatch_log_group.consignment_export_task.arn]
+  }
+}
+
 resource "aws_iam_role" "consignment_export_task" {
   name = "consignment_export_task_role_${var.environment}"
   assume_role_policy = data.aws_iam_policy_document.consignment_export_task_assume_role.json

--- a/modules/consignment_export/logs.tf
+++ b/modules/consignment_export/logs.tf
@@ -1,4 +1,4 @@
-resource "aws_cloudwatch_log_group" "database_migration_task" {
+resource "aws_cloudwatch_log_group" "consignment_export_task" {
   name              = local.export_task_log_group_name
   retention_in_days = 30
 }

--- a/modules/consignment_export/outputs.tf
+++ b/modules/consignment_export/outputs.tf
@@ -2,6 +2,10 @@ output "task_id" {
   value = aws_ecs_task_definition.run_consignment_export.family
 }
 
+output "task_arn" {
+  value = aws_ecs_task_definition.run_consignment_export.arn
+}
+
 output "container_id" {
   value = local.container_name
 }

--- a/modules/frontend/ecs.tf
+++ b/modules/frontend/ecs.tf
@@ -1,6 +1,6 @@
 resource "aws_ecs_cluster" "tdr-prototype-ecs" {
   name = "tdr-prototype-ecs-${var.environment}"
-  
+
   tags = merge(
     var.common_tags,
     map("Name", var.tag_name)
@@ -22,13 +22,13 @@ resource "aws_ecs_cluster" "tdr-prototype-ecs" {
 
 resource "aws_ecs_task_definition" "app" {
   family                   = "${var.app_name}-${var.environment}"
-  execution_role_arn       = var.ecs_task_execution_role
+  execution_role_arn       = aws_iam_role.frontend_ecs_execution.arn
   network_mode             = "awsvpc"
   requires_compatibilities = ["FARGATE"]
   cpu                      = var.fargate_cpu
   memory                   = var.fargate_memory
   container_definitions    = data.template_file.app.rendered
-  task_role_arn            = var.ecs_task_execution_role
+  task_role_arn            = aws_iam_role.frontend_ecs_task.arn
 
   tags = merge(
     var.common_tags,
@@ -59,3 +59,66 @@ resource "aws_ecs_service" "app" {
   depends_on = [aws_alb_listener.front_end]
 }
 
+resource "aws_iam_role" "frontend_ecs_execution" {
+  name = "frontend_ecs_execution_role_${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = merge(
+    var.common_tags,
+    map(
+      "Name", "frontend-ecs-execution-iam-role-${var.environment}",
+    )
+  )
+}
+
+resource "aws_iam_role" "frontend_ecs_task" {
+  name = "frontend_ecs_task_role_${var.environment}"
+  assume_role_policy = data.aws_iam_policy_document.ecs_assume_role.json
+
+  tags = merge(
+    var.common_tags,
+    map(
+      "Name", "frontend-ecs-task-iam-role-${var.environment}",
+    )
+  )
+}
+
+data "aws_iam_policy_document" "ecs_assume_role" {
+  version = "2012-10-17"
+
+  statement {
+    effect  = "Allow"
+    actions   = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "frontend_ecs_execution_ssm" {
+  role       = aws_iam_role.frontend_ecs_execution.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess"
+}
+
+resource "aws_iam_role_policy_attachment" "frontend_ecs_execution" {
+  role       = aws_iam_role.frontend_ecs_execution.name
+  policy_arn = aws_iam_policy.frontend_ecs_execution.arn
+}
+
+resource "aws_iam_policy" "frontend_ecs_execution" {
+  name   = "frontend_ecs_execution_policy_${var.environment}"
+  path   = "/"
+  policy = data.aws_iam_policy_document.frontend_ecs_execution.json
+}
+
+data "aws_iam_policy_document" "frontend_ecs_execution" {
+  statement {
+    actions   = [
+      "logs:CreateLogStream",
+      "logs:PutLogEvents"
+    ]
+    resources = [aws_cloudwatch_log_group.tdr_application_log_group.arn]
+  }
+}

--- a/modules/frontend/variables.tf
+++ b/modules/frontend/variables.tf
@@ -50,11 +50,6 @@ variable "app_name" {
   default     = "tdr-application"
 }
 
-variable "ecs_task_execution_role" {
-  description = "Role arn for the ecsTaskExecutionRole"
-  default     = "arn:aws:iam::247222723249:role/ecsTaskExecutionRole"
-}
-
 variable "health_check_path" {
   default = "/"
 }

--- a/root.tf
+++ b/root.tf
@@ -143,6 +143,7 @@ module "api" {
   lb_listener = module.frontend.load_balancer_listener
   app_name = "sangria-graphql"
   export_task_id = module.consignment_export.task_id
+  export_task_arn = module.consignment_export.task_arn
   export_container_id = module.consignment_export.container_id
   export_cluster_arn = module.consignment_export.cluster_arn
   export_security_group_id = module.consignment_export.security_group_id

--- a/root.tf
+++ b/root.tf
@@ -137,7 +137,6 @@ module "api" {
   app_port = 8080
   ecs_public_subnet = module.ecs_network.ecs_public_subnet
   ecs_private_subnet = module.ecs_network.ecs_private_subnet
-  ecs_task_execution_role = "arn:aws:iam::247222723249:role/ecsTaskExecutionRole"
   ecs_vpc = local.ecs_vpc
   fargate_cpu = 1024
   fargate_memory = 2048


### PR DESCRIPTION
Add IAM role and policy to allow the API to call ECS to start the consignment export task.

Easiest to review commit-by-commit because I've done some IAM role and policy tidying to make the API config change easier.